### PR TITLE
Remove extra semicolon

### DIFF
--- a/common/apsi/fourq/crypto_util.c
+++ b/common/apsi/fourq/crypto_util.c
@@ -238,4 +238,4 @@ const char *FourQ_get_error_message(ECCRYPTO_STATUS Status)
     } else {
         return mapping[Status].string;
     }
-};
+}


### PR DESCRIPTION
When building with -Wextra-semi I get warnings/errors for an extra semicolon at the end of crypto_util.c

